### PR TITLE
replace ',' with '.' in float type frequency on german systems

### DIFF
--- a/param.c
+++ b/param.c
@@ -177,6 +177,12 @@ std::string GetTransponderUrlParameters(const cChannel* channel) {
      auto PrintFloat = [](float& f) -> std::string {
         char buf[32];
         snprintf(buf, sizeof(buf), "%.3f", f);
+        for (size_t i = 0; i < strlen(buf); i++) {
+            if (buf[i] == ',') {
+                buf[i] = '.';
+                break;
+            }
+        }
         return buf;
         };
 


### PR DESCRIPTION
I found the issue described [here](https://www.vdr-portal.de/forum/index.php?thread/136100-vdr-plugin-satip-detected-invalid-status-code-400-mit-octopusnet/&postID=1367825#post1367825).
The OctopusNet does not accept a ',' in the freqency field from the setup request.
Here the output from a trace from the setup request:
Request: SETUP rtsp://10.1.15.217/?src=1&freq=**10714,000**&pol=h&ro=0.35&msys=dvbs2&mtype=8psk&sr=22000&fec=23 RTSP/1.0\r\n
The issue only occurs on system with ',' as separator in float values.